### PR TITLE
Removed import error

### DIFF
--- a/classification_model/plot_results.py
+++ b/classification_model/plot_results.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 from sklearn.utils import check_random_state
 
-from classification_model.result_directories import ResultDirectories
+from .result_directories import ResultDirectories
 from pycsca.constants import *
 from pycsca.csv_reader import CSVReader
 from pycsca.plot_utils import classwise_barplot_for_dataset, \

--- a/classification_model/pvalues_calculation.py
+++ b/classification_model/pvalues_calculation.py
@@ -7,7 +7,7 @@ import pickle
 from itertools import product
 from scipy.stats import fisher_exact
 from statsmodels.stats.multitest import multipletests
-from classification_model.result_directories import ResultDirectories
+from .result_directories import ResultDirectories
 from pycsca import *
 
 

--- a/classification_model/train_models.py
+++ b/classification_model/train_models.py
@@ -11,7 +11,7 @@ from itertools import product
 from sklearn.model_selection import StratifiedKFold, StratifiedShuffleSplit
 from sklearn.utils import check_random_state
 
-from classification_model.result_directories import ResultDirectories
+from .result_directories import ResultDirectories
 from pycsca.classification_test import optimize_search_cv
 from pycsca.classifiers import classifiers_space
 from pycsca.constants import *


### PR DESCRIPTION
Removed the import error for ResultDirectories

raceback (most recent call last):


  File "/autosca-tool/classification_model/train_models.py", line 12, in <module>


    from classification_model.result_directories import ResultDirectories


ModuleNotFoundError: No module named 'classification_model'


Finished kccv classification model training, execution took 1 seconds


Generating report


Traceback (most recent call last):


  File "/autosca-tool/classification_model/pvalues_calculation.py", line 11, in <module>


    from classification_model.result_directories import ResultDirectories


ModuleNotFoundError: No module named 'classification_model'


Plotting the machine learning results


Traceback (most recent call last):


  File "/autosca-tool/classification_model/plot_results.py", line 13, in <module>


    from classification_model.result_directories import ResultDirectories


ModuleNotFoundError: No module named 'classification_model'

